### PR TITLE
Move `sha3` over to `optionalDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "browserify-sha3": "^0.0.4",
+    "browserify-sha3": "^0.0.4"
+  },
+  "optionalDependencies": {
     "sha3": "^1.2.2"
   },
   "browser": "browser.js",


### PR DESCRIPTION
`sha3@1.2.2` with its C implementation is about 45x faster than `sha3@2.0.0`'s pure JS implementation, so I think it makes sense to keep 1.2.2 around (see https://github.com/phusion/node-sha3/pull/44#issuecomment-437689120 for benchmarks).

Also, `browserify-sha3` uses `js-sha3`, which is currently the fastest pure-js implementation, so it makes sense to keep it for the browser-fallback.

Additionally, many users installing this library have issues doing so due to `sha3@1.2.2`'s dependency on node-gyp, python, and other missing build tools.

To work around this issue `sha3@1.2.2` can be installed as an `optionalDependency`, which will allow for the install of `sha3` to fail, but the install of `keccakjs` to still succeed (just like is done with the `scrypt` dependency in `scrypt.js`).