### PR TITLE
Upgraded sha3 package to latest as of May 2, 2019

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keccakjs",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Keccak hash (SHA3) in Node.js and in the browser. Fast & simple.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "browserify-sha3": "^0.0.4",
-    "sha3": "^1.2.2"
+    "sha3": "^2.0.1"
   },
   "browser": "browser.js",
   "devDependencies": {


### PR DESCRIPTION
Fixes: https://github.com/axic/keccakjs/issues/8

sha3 1.2.2 doesn't build on macOS 10.14.4.

example:
```10 warnings and 12 errors generated.
make: *** [Release/obj.target/sha3/src/addon.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:196:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:256:12)
gyp ERR! System Darwin 18.5.0
gyp ERR! command "/usr/local/Cellar/node/12.1.0/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/adameverspaugh/keccakjs/node_modules/sha3
gyp ERR! node -v v12.1.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! sha3@1.2.2 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sha3@1.2.2 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/.../.npm/_logs/2019-05-02T16_31_18_421Z-debug.log```